### PR TITLE
remove boost dependecy

### DIFF
--- a/src/cryptoki/CMakeLists.txt
+++ b/src/cryptoki/CMakeLists.txt
@@ -16,14 +16,12 @@ include_directories("${PROJECT_SOURCE_DIR}/src/include")
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+include(FindLibUUID)
 include(FindSqlite3)
 include(FindBotan)
 
-set(Boost_USE_STATIC_LIBS OFF)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
 
-find_package(Boost 1.53 REQUIRED)
+find_package(LibUUID REQUIRED)
 find_package(Sqlite3 REQUIRED)
 find_package(Botan REQUIRED)
 find_package(TCLib REQUIRED)
@@ -37,15 +35,15 @@ else()
     message(FATAL_ERROR "Cannot find LibConfig library")
 endif()
 
-if (Boost_FOUND)
-    include_directories(${Boost_INCLUDE_DIRS})
+if (LIBUUID_FOUND)
+    include_directories(${LibUUID_INCLUDE_DIRS})
 else()
-    message(FATAL_ERROR "Cannot find boost library")
+    message(FATAL_ERROR "Cannot find LibUUID")
 endif()
 
 if (SQLITE3_FOUND)
     include_directories(${SQLITE3_INCLUDE_DIRS})
-  else()
+else()
     message(FATAL_ERROR "Cannot find sqlite3 library")
 endif()
 
@@ -89,12 +87,12 @@ set(HSM_SRC
 
 
 add_library(pkcs11 SHARED pkcs11.cpp ${HSM_SRC})
-target_link_libraries(pkcs11 dtc ${Boost_LIBRARIES} ${SQLITE3_LIBRARIES} ${BOTAN_LIBRARIES} ${LIBCONFIG_LIBRARIES})
+target_link_libraries(pkcs11 dtc ${SQLITE3_LIBRARIES} ${BOTAN_LIBRARIES} ${LIBCONFIG_LIBRARIES} ${LIBUUID_LIBRARIES})
 
 
 
 add_executable(pkcs11_test test.c)
-target_link_libraries(pkcs11_test pkcs11 ${Boost_LIBRARIES} ${SQLITE3_LIBRARIES} ${BOTAN_LIBRARIES})
+target_link_libraries(pkcs11_test pkcs11 ${SQLITE3_LIBRARIES} ${BOTAN_LIBRARIES})
 
 install(TARGETS pkcs11 DESTINATION lib)
 install(FILES ./cryptoki.conf DESTINATION etc)

--- a/src/cryptoki/hsm/Session.cpp
+++ b/src/cryptoki/hsm/Session.cpp
@@ -19,9 +19,6 @@
 
 #include <algorithm>
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 #include <botan/emsa.h>
 #include <botan/md5.h>
 #include <botan/sha160.h>
@@ -36,6 +33,7 @@
 #include <dtc.h>
 #include <iostream>
 #include <botan/lookup.h>
+#include <uuid/uuid.h>
 
 #include "Session.h"
 #include "Slot.h"
@@ -84,6 +82,13 @@ namespace {
 
     CK_SESSION_HANDLE actualHandle = 0;
 
+    std::string get_uuid() {
+        uuid_t uuid;
+        char tmp_uuid[37];
+        uuid_generate(uuid);
+        uuid_unparse(uuid, tmp_uuid);
+        return string(tmp_uuid);
+    }
 }
 
 Session::Session(CK_FLAGS flags, CK_VOID_PTR pApplication,
@@ -686,8 +691,7 @@ KeyPair Session::generateKeyPair(CK_MECHANISM_PTR pMechanism, CK_ATTRIBUTE_PTR p
     switch (pMechanism->mechanism) {
         case CKM_RSA_PKCS_KEY_PAIR_GEN: {
             // RSA is the only accepted method...
-            boost::uuids::random_generator uuidGen;
-            string keyHandler = to_string(uuidGen());
+            string keyHandler = get_uuid();
             // TODO: check if generated uuid is already taken.
 
             Application &app = getCurrentSlot().getApplication();


### PR DESCRIPTION
Using uuid instead of boost/uuid, uuid was already being used at dtc so no new dependencies.
Close #39 