### PR TITLE
Fix warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 project(libdtc)
 
+set(CMAKE_C_FLAGS_DEBUG "-Wall")
+set(CMAKE_CXX_FLAGS_DEBUG "-Wall")
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${libdtc_SOURCE_DIR}/cmake)

--- a/src/dtc.c
+++ b/src/dtc.c
@@ -727,7 +727,6 @@ static int store_key_shares_nodes(dtc_ctx_t *ctx, const char *key_id,
     void *remaining_key;
     unsigned prev, timeout_secs, timeout_usecs, retries = 2;
     uint16_t val;
-    double timeout;
     Buffer_t *keys;
 
     pub_op.version = 1;
@@ -833,7 +832,7 @@ int dtc_sign(dtc_ctx_t *ctx, const key_metainfo_t *key_metainfo,
     int threshold = tc_key_meta_info_k(key_metainfo);
     int nodes_cant = tc_key_meta_info_l(key_metainfo);
     struct handle_sign_key_data sign_key_data;
-    unsigned timeout, timeout_secs, timeout_usecs, retries = 2;
+    unsigned timeout_secs, timeout_usecs, retries = 2;
     signature_share_t *signature;
     Buffer_t *signatures_buffer;
     signature_share_t *signatures[nodes_cant];

--- a/src/dtc.c
+++ b/src/dtc.c
@@ -81,29 +81,6 @@ static void free_nodes(unsigned int nodes_cant, struct node_info *node)
     free(node);
 }
 
-/* Release the memory allocated within the dtc_configuration struct, do not
- * release the struct.
- */
-static void free_conf(struct dtc_configuration *conf)
-{
-    unsigned i;
-    if(!conf)
-        return;
-    for(i = 0; i < conf->nodes_cant; i++)
-        if(conf->nodes[i].public_key)
-            free(conf->nodes[i].public_key);
-    free_nodes(conf->nodes_cant, (struct node_info *)conf->nodes);
-    conf->nodes_cant = 0;
-    if(conf->public_key)
-        free((void *)conf->public_key);
-    if(conf->private_key) {
-        memset((void *)conf->private_key, '\0', strlen(conf->private_key));
-        free((void *)conf->private_key);
-    }
-    if(conf->instance_id)
-        free((void *)conf->instance_id);
-}
-
 void divide_timeout(uint16_t ctx_timeout, unsigned retries,
                     unsigned *timeout_secs, unsigned *timeout_usecs)
 {

--- a/src/node.c
+++ b/src/node.c
@@ -312,30 +312,6 @@ static int read_configuration(int argc, char *argv[],
     return 0;
 }
 
-static int auth_pub(database_t *conn, const char *instance_id,
-                    const char *auth_user)
-{
-    char *output;
-    int ret;
-    if(DTC_ERR_NONE != db_get_pub_token(conn, instance_id, &output))
-        return 0;
-    ret = strcmp(output, auth_user) == 0;
-    free(output);
-    return ret;
-}
-
-static int auth_router(database_t *conn, const char *instance_id,
-                       const char *auth_user)
-{
-    char *output;
-    int ret;
-    if(DTC_ERR_NONE != db_get_router_token(conn, instance_id, &output))
-        return 0;
-    ret = strcmp(output, auth_user) == 0;
-    free(output);
-    return ret;
-}
-
 // Serialize and send an op to router, will write the instance id as first frame
 // of the message, that's used to select the destination in a router socket.
 static int send_op(const char *instance_id, const struct op_req *op, void *socket)
@@ -517,7 +493,6 @@ void handle_sign_pub(database_t *db_conn, void *router_socket,
     size_t msg_len;
     const signature_share_t *signature;
     bytes_t *msg_bytes;
-    int ret;
 
     if(pub_op->version != 1) {
         LOG(LOG_LVL_ERRO, "version %" PRIu16 " not supported.",
@@ -1088,12 +1063,6 @@ static void zap_handler(void *zap_data_)
         char *address = s_recv(sock);
         char *identity = s_recv(sock);
         char *mechanism = s_recv(sock);
-        int size = zmq_recv(sock, client_key, 32, 0);
-
-        //LOG(LOG_LVL_DEBG, "Message of size: %d, sequence number: %s,"
-        //                  "domain: %s, address: %s, identity: %s, "
-        //                  "mechanism: %s. received.",size, sequence, domain,
-        //                  address, identity, mechanism);
 
         char client_key_text [42];
         zmq_z85_encode(client_key_text, client_key, 32);


### PR DESCRIPTION
I removed some warnings at dtc and included -Wall when compiling in debug mode. This should prevent new warnings and encourage developers to remove the existent ones.