### PR TITLE
remove boost installation at travis

### DIFF
--- a/.install_dependencies.sh
+++ b/.install_dependencies.sh
@@ -3,7 +3,6 @@
 sudo apt-get update -qq
 
 sudo apt-get install -y check
-sudo apt-get install -y libboost-all-dev
 sudo apt-get install -y libjson-c-dev
 sudo apt-get install -y libconfig-dev
 sudo apt-get install -y libsqlite3-dev


### PR DESCRIPTION
As we are not using boost anymore we don't need to download it for running tests.