### PR TITLE
fix overriding of flags caused by bad definition at CMakeList

### DIFF
--- a/.install_dependencies.sh
+++ b/.install_dependencies.sh
@@ -12,7 +12,7 @@ sudo apt-get install -y uuid-dev
 wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.9.tar.gz
 tar -xzC /tmp -f libsodium-1.0.9.tar.gz
 
-wget http://download.zeromq.org/zeromq-4.1.4.tar.gz
+wget https://github.com/zeromq/zeromq4-1/releases/download/v4.1.4/zeromq-4.1.4.tar.gz
 tar -xzC /tmp -f zeromq-4.1.4.tar.gz
 
  #wget http://botan.randombit.net/releases/Botan-1.11.29.tgz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(libdtc)
 
-set(CMAKE_C_FLAGS_DEBUG "-Wall")
-set(CMAKE_CXX_FLAGS_DEBUG "-Wall")
+set(CMAKE_C_FLAGS_DEBUG " ${CMAKE_C_FLAGS_DEBUG} -Wall")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-
 include(FindZeroMQ)
 include(FindSqlite3)
 include(FindJSON-C)


### PR DESCRIPTION
When setting debug, -Wall overrides -g from debugging. This commit preserves -g and any other flags defined when running cmake.