### PR TITLE
Link pkcs11 lib against static version of dtc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.8)
 project(libdtc)
 
 set(CMAKE_C_FLAGS_DEBUG " ${CMAKE_C_FLAGS_DEBUG} -Wall")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
-
 find_package(Threads REQUIRED)
 
 include(FindLibConfig)
@@ -49,28 +47,39 @@ set(DTC_FILES
 
 add_library(common STATIC ${COMMON_FILES})
 set_target_properties(common PROPERTIES POSITION_INDEPENDENT_CODE ON)
-add_library(dtc SHARED ${DTC_FILES})
-
-if(THREADS_HAVE_PTHREAD_ARG)
-    target_compile_options(PUBLIC dtc "-pthread")
-endif()
-if(CMAKE_THREAD_LIBS_INIT)
-    target_link_libraries(dtc "${CMAKE_THREAD_LIBS_INIT}")
-endif()
+add_library(dtc_obj OBJECT ${DTC_FILES})
+set_target_properties(dtc_obj PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(dtc_obj PUBLIC include)
 
 target_link_libraries(common ${LIBCONFIG_LIBRARIES}
                              ${LIBUUID_LIBRARIES}
                              ${ZEROMQ_LIBRARIES})
 
-target_link_libraries(dtc common
-                          ${JSON-C_LIBRARIES}
-                          ${LIBCONFIG_LIBRARIES}
-                          ${LIBSODIUM_LIBRARIES}
-                          ${SQLITE3_LIBRARIES}
-                          ${TCLIB_LIBRARIES}
-                          ${ZEROMQ_LIBRARIES})
+add_library(dtc SHARED $<TARGET_OBJECTS:dtc_obj>)
+add_library(dtc_static STATIC $<TARGET_OBJECTS:dtc_obj>)
+set_target_properties(dtc_static PROPERTIES OUTPUT_NAME dtc)
+if(THREADS_HAVE_PTHREAD_ARG)
+    target_compile_options(dtc PUBLIC "-pthread")
+    target_compile_options(dtc_static PUBLIC "-pthread")
+endif()
+if(${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(dtc "${CMAKE_THREAD_LIBS_INIT}")
+    target_link_libraries(dtc_static "${CMAKE_THREAD_LIBS_INIT}")
+endif()
+
+set(dtc_dependencies ${JSON-C_LIBRARIES}
+                     ${LIBCONFIG_LIBRARIES}
+                     ${LIBSODIUM_LIBRARIES}
+                     ${SQLITE3_LIBRARIES}
+                     ${TCLIB_LIBRARIES}
+                     ${ZEROMQ_LIBRARIES})
+
+target_link_libraries(dtc common ${dtc_dependencies})
+target_link_libraries(dtc_static common ${dtc_dependencies})
 
 target_include_directories(common PUBLIC include ../include)
 target_include_directories(dtc PUBLIC ../include)
+target_include_directories(dtc_static PUBLIC ../include)
 
 install(TARGETS dtc DESTINATION lib)
+install(TARGETS dtc_static DESTINATION lib)

--- a/src/cryptoki/CMakeLists.txt
+++ b/src/cryptoki/CMakeLists.txt
@@ -64,6 +64,6 @@ set(HSM_SRC
 
 
 add_library(pkcs11 SHARED pkcs11.cpp ${HSM_SRC})
-target_link_libraries(pkcs11 dtc ${SQLITE3_LIBRARIES} ${BOTAN_LIBRARIES} ${LIBCONFIG_LIBRARIES} ${LIBUUID_LIBRARIES})
+target_link_libraries(pkcs11 dtc_static ${SQLITE3_LIBRARIES} ${BOTAN_LIBRARIES} ${LIBCONFIG_LIBRARIES} ${LIBUUID_LIBRARIES})
 
 install(TARGETS pkcs11 DESTINATION lib)

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -50,7 +50,7 @@ add_executable(tchsm_node node.c)
 
 
 if(THREADS_HAVE_PTHREAD_ARG)
-    target_compile_options(PUBLIC tchsm_node "-pthread")
+    target_compile_options(tchsm_node PUBLIC "-pthread")
 endif()
 if(CMAKE_THREAD_LIBS_INIT)
     target_link_libraries(tchsm_node "${CMAKE_THREAD_LIBS_INIT}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
+find_package(Threads REQUIRED)
 
 find_package(TCLib REQUIRED)
 include_directories(${TCLIB_INCLUDE_DIRS})
@@ -24,6 +25,13 @@ set(tests
 foreach(test ${tests})
     add_executable(${test} ${test}.c)
     target_link_libraries(${test} ${CHECK_LIBRARIES} dtc node_common m ${REALTIME_LIBRARIES})
+
+    if(THREADS_HAVE_PTHREAD_ARG)
+        target_compile_options(${test} PUBLIC "-pthread")
+    endif()
+    if(CMAKE_THREAD_LIBS_INIT)
+        target_link_libraries(${test} "${CMAKE_THREAD_LIBS_INIT}")
+    endif()
 
     add_test(NAME ${test} COMMAND ${test})
 

--- a/tests/database_test.c
+++ b/tests/database_test.c
@@ -2,7 +2,6 @@
 
 #include <assert.h>
 #include <dirent.h>
-#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Now we're requiring CMake 2.8.8 as we are using OBJECT libraries.
Added new target dtc_static.

Fixes #88 