### PR TITLE
change vector.data() by &vector.at[0]

### DIFF
--- a/src/cryptoki/Session.cpp
+++ b/src/cryptoki/Session.cpp
@@ -840,7 +840,7 @@ void Session::signFinal(CK_BYTE_PTR pSignature, CK_ULONG_PTR pulSignatureLen) {
     // encoded signature is a byte vector, so data size == vector.size().
     *pulSignatureLen = encoded_signature.size();
 
-    CK_BYTE_PTR data = static_cast<CK_BYTE_PTR> (encoded_signature.data());
+    CK_BYTE_PTR data = static_cast<CK_BYTE_PTR> (&encoded_signature[0]);
     std::copy(data, data + *pulSignatureLen, pSignature);
 
     keyMetainfo_.reset();


### PR DESCRIPTION
Turns out that on Botan 1.10 SecureVector is not a specialization of std::vector, so it does not contains .data() or .front() as secure_vector does since Botan 1.11. 