### PR TITLE
Sqlite version

### DIFF
--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
+include (CheckFunctionExists)
 
 find_package(Threads REQUIRED)
 
@@ -45,6 +46,16 @@ set(NODE_COMMON_FILES
 add_library(node_common STATIC ${NODE_COMMON_FILES})
 target_link_libraries(node_common common)
 set_target_properties(node_common PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_REQUIRED_LIBRARIES ${SQLITE3_LIBRARIES})
+check_function_exists("sqlite3_unlock_notify" SQLITE3_HAVE_UNLOCK_NOTIFY)
+set(CMAKE_REQUIRED_LIBRARIES)
+if(NOT SQLITE3_HAVE_UNLOCK_NOTIFY)
+    message(STATUS "SQLITE3 Not compiled using SQLITE_ENABLE_UNLOCK_NOTIFY")
+else()
+    target_compile_definitions(node_common PUBLIC SQLITE3_HAVE_UNLOCK_NOTIFY=1)
+endif()
+
 
 add_executable(tchsm_node node.c)
 

--- a/src/node/blocking_sql3.h
+++ b/src/node/blocking_sql3.h
@@ -2,6 +2,7 @@
 // https://www.sqlite.org/unlock_notify.html
 // The SQLite's license states that this code belongs to the public domain.
 
+#if (SQLITE3_HAVE_UNLOCK_NOTIFY)
 /*
  * A pointer to an instance of this structure is passed as the user-context
  * pointer when registering for an unlock-notify callback.
@@ -27,7 +28,6 @@ static void unlock_notify_cb(void **apArg, int nArg){
     }
 }
 
-#if (SQLITE_VERSION_NUMBER >= 3006012)
 /*
  * This function assumes that an SQLite API call (either sqlite3_prepare_v2() or
  * sqlite3_step()) has just returned SQLITE_LOCKED. The argument is the
@@ -87,7 +87,7 @@ static int wait_for_unlock_notify(sqlite3 *db){
  */
 int sqlite3_blocking_step(sqlite3_stmt *pStmt){
     int rc;
-#if (SQLITE_VERSION_NUMBER >= 3006012)
+#if (SQLITE3_HAVE_UNLOCK_NOTIFY)
     while(SQLITE_LOCKED == (rc = sqlite3_step(pStmt))){
         rc = wait_for_unlock_notify(sqlite3_db_handle(pStmt));
         if(rc != SQLITE_OK)
@@ -118,7 +118,7 @@ int sqlite3_blocking_prepare_v2(
     const char **pz)          /* OUT: End of parsed string */
 {
     int rc;
-#if (SQLITE_VERSION_NUMBER >= 3006012)
+#if (SQLITE3_HAVE_UNLOCK_NOTIFY)
     while(SQLITE_LOCKED == (rc = sqlite3_prepare_v2(
                                         db, zSql, nSql, ppStmt, pz))){
         rc = wait_for_unlock_notify(db);

--- a/src/node/database.c
+++ b/src/node/database.c
@@ -147,7 +147,11 @@ database_t *db_init_connection(const char *path, int create_db_tables){
             NULL);
     if(rc != SQLITE_OK) {
         LOG(LOG_LVL_CRIT, "Unable to open the database:%s",
+#if (SQLITE_VERSION_NUMBER >= 3007015)
             sqlite3_errstr(rc));
+#else
+            sqlite3_errmsg(&ret->ppDb);
+#endif
         sqlite3_close(ret->ppDb);
         free(ret);
         return NULL;


### PR DESCRIPTION
Make compilation with older version of sqlite3 possible. Add macros to optionally use sqlite3_errstr and sqlite3_unlock_notify 