### PR TITLE
Make node and cryptoki build optional

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,14 @@
 add_subdirectory(core)
-add_subdirectory(cryptoki)
-add_subdirectory(node)
+
+option(ENABLE_CRYPTOKI "Enable the pkcs11 lib" ON)
+option(ENABLE_NODE "Enable the tchsm node" ON)
+
+if(ENABLE_CRYPTOKI)
+    add_subdirectory(cryptoki)
+ endif()
+
+if(ENABLE_NODE)
+    add_subdirectory(node)
+endif()
 
 install(FILES include/dtc.h DESTINATION include)


### PR DESCRIPTION
This makes the node and cryptoki build process optional, this is needed to avoid having all the requirements to compile one of the modules. So if you're only compiling the node you can disable cryptoki:
```shell
cmake -DENABLE_CRYPTOKI=OFF ..
```

And the same in the other way, if you want to compile only cryptoki you can disable the node:
```shell
cmake -DENABLE_NODE=OFF ..
```