### PR TITLE
v1.0

### DIFF
--- a/scripts/create_config.py
+++ b/scripts/create_config.py
@@ -377,7 +377,7 @@ def main(argv=None):
         "--multiple_connections",
         help="""Behaviour when the node receives multiple connections from an
                 instance""",
-        dafault=DEFAULT_MULTIPLE_CONNECTIONS)
+        default=DEFAULT_MULTIPLE_CONNECTIONS)
     args = parser.parse_args()
 
     if args.output_dir is not None:
@@ -414,7 +414,7 @@ def main(argv=None):
             masters,
             index,
             args.interface,
-            args.multiple_connections
+            args.multiple_connections,
             args.database)
         count += 1
 

--- a/scripts/create_config.py
+++ b/scripts/create_config.py
@@ -27,6 +27,8 @@ DEFAULT_NODE_DATABASE = abspath("node")
 
 DEFAULT_CRYPTOKI_DATABASE = abspath("cryptoki")
 
+DEFAULT_MULTIPLE_CONNECTIONS = "SAME_IP"
+
 
 def correct_input(nodes_info):
     """
@@ -153,6 +155,7 @@ def create_node_config(
      masters,
      index,
      interface,
+     multiple_connections,
      database):
     """Creates one node configuration into the specified file.
 
@@ -161,6 +164,8 @@ def create_node_config(
     masters -- a dictionary in which the keys are the mastrs ids and the value the masters public keys
     index -- node id
     interface -- interface in the node config
+    multiple_connections -- Behaviour when receiving multiple connections from
+     the same instance.
     database -- prefix in the database path in the nodes config
     """
     config_file.write("node:\n{\n")
@@ -173,7 +178,7 @@ def create_node_config(
         config_file.write("\t\tpublic_key=\"" + master_key[0] + "\",\n")
         config_file.write("\t\tid=\"" + master_id + "\"\n")
         config_file.write("\t\t}")
-        
+
         if loop_index < len(masters) - 1:
             config_file.write(",\n")
 
@@ -190,6 +195,7 @@ def create_node_config(
     config_file.write("\tprivate_key=\"" + node_info[3] + "\",\n")
     config_file.write("\tpublic_key=\"" + node_info[2] + "\",\n")
     config_file.write("\tinterface=\"" + interface + "\"\n")
+    config_file.write("\tmultiple_connections=\"" + multiple_connections + "\",\n")
     config_file.write("}")
 
 
@@ -366,6 +372,12 @@ def main(argv=None):
         "--threshold",
         help="custom threshold for the cryptoki config",
         default=-1)
+    parser.add_argument(
+        "-mc",
+        "--multiple_connections",
+        help="""Behaviour when the node receives multiple connections from an
+                instance""",
+        dafault=DEFAULT_MULTIPLE_CONNECTIONS)
     args = parser.parse_args()
 
     if args.output_dir is not None:
@@ -402,6 +414,7 @@ def main(argv=None):
             masters,
             index,
             args.interface,
+            args.multiple_connections
             args.database)
         count += 1
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,8 +11,8 @@ if(ENABLE_NODE)
     add_subdirectory(node)
 endif()
 
-set(TCHSMLibDTC_VERSION_MAJOR 0)
-set(TCHSMLibDTC_VERSION_MINOR 1)
+set(TCHSMLibDTC_VERSION_MAJOR 1)
+set(TCHSMLibDTC_VERSION_MINOR 0)
 
 configure_file(
     "${PROJECT_SOURCE_DIR}/src/include/dtc.h.in"

--- a/src/core/dtc.c
+++ b/src/core/dtc.c
@@ -136,7 +136,7 @@ static char *get_connection_id()
 {
     size_t len = sizeof(pid_t) * 3;
     int ret_val;
-    char ret = malloc(sizeof(char) * len);
+    char *ret = (char *)malloc(sizeof(char) * len);
 
     ret_val = snprintf(ret, len, "%ld", (long)getpid());
     if(ret_val >= len) {

--- a/src/core/include/messages.h
+++ b/src/core/include/messages.h
@@ -21,7 +21,7 @@ enum OP {
 };
 
 struct store_key_pub{
-    const char *instance_id;
+    const char *connection_id;
     const char *key_id;
 };
 
@@ -47,6 +47,7 @@ struct store_key_ack {
 };
 
 struct delete_key_share_pub {
+    const char *connection_id;
     const char *key_id;
 };
 
@@ -56,6 +57,7 @@ struct delete_key_share_req {
 };
 
 struct sign_pub {
+    const char *connection_id;
     const char *signing_id;
     const char *key_id;
     uint8_t *message;

--- a/src/core/include/utilities.h
+++ b/src/core/include/utilities.h
@@ -3,6 +3,8 @@
 
 #include <libconfig.h>
 
+// TODO document
+char *create_identity(const char *instance_id, const char *connection_id);
 
 /**
  * Auxiliary function to read an uint16_t from a config_setting_t, it's read

--- a/src/core/messages.c
+++ b/src/core/messages.c
@@ -23,8 +23,8 @@ static struct json_object *serialize_store_key_pub(
 
     ret = json_object_new_object();
 
-    json_object_object_add(ret, "instance_id",
-                            json_object_new_string(store_key_pub->instance_id));
+    json_object_object_add(ret, "connection_id",
+                            json_object_new_string(store_key_pub->connection_id));
     json_object_object_add(ret, "key_id",
                            json_object_new_string(store_key_pub->key_id));
     return ret;
@@ -40,11 +40,11 @@ static union command_args *unserialize_store_key_pub(struct json_object *in,
     if(version != 1)
         goto err_exit;
 
-    if(!json_object_object_get_ex(in, "instance_id", &temp)){
-        LOG(LOG_LVL_CRIT, "Key \"instance_id\" does not exists.");
+    if(!json_object_object_get_ex(in, "connection_id", &temp)){
+        LOG(LOG_LVL_CRIT, "Key \"connection_id\" does not exists.");
         goto err_exit;
     }
-    ret->instance_id = strdup(json_object_get_string(temp));
+    ret->connection_id = strdup(json_object_get_string(temp));
 
     if(!json_object_object_get_ex(in, "key_id", &temp)) {
         LOG(LOG_LVL_CRIT, "Key \"key_id\" does not exists.");
@@ -61,7 +61,7 @@ err_exit:
 
 int delete_store_key_pub(union command_args *data) {
     struct store_key_pub *store_key_pub = &data->store_key_pub;
-    free((void *)store_key_pub->instance_id);
+    free((void *)store_key_pub->connection_id);
     free((void *)store_key_pub->key_id);
     free(data);
     return 0;
@@ -275,7 +275,9 @@ static struct json_object *serialize_delete_key_share_pub(
     ret = json_object_new_object();
 
     json_object_object_add(ret, "key_id",
-                           json_object_new_string(delete_key_share->key_id));
+            json_object_new_string(delete_key_share->key_id));
+    json_object_object_add(ret, "connection_id",
+            json_object_new_string(delete_key_share->connection_id));
     return ret;
 }
 
@@ -296,6 +298,12 @@ static union command_args *unserialize_delete_key_share_pub(
     }
     ret->key_id = strdup(json_object_get_string(temp));
 
+    if(!json_object_object_get_ex(in, "connection_id", &temp)) {
+        LOG(LOG_LVL_CRIT, "Key \"connection\" does not exists.");
+        goto err_exit;
+    }
+    ret->connection_id = strdup(json_object_get_string(temp));
+
     return ret_union;
 
 err_exit:
@@ -306,6 +314,7 @@ err_exit:
 static int delete_delete_key_share_pub(union command_args *data) {
     struct delete_key_share_pub *delete_key_share = &data->delete_key_share_pub;
     free((void *)delete_key_share->key_id);
+    free((void *)delete_key_share->connection_id);
     free(data);
     return 0;
 }
@@ -384,6 +393,8 @@ static struct json_object *serialize_sign_pub(
 
     ret = json_object_new_object();
 
+    json_object_object_add(ret, "connection_id",
+                           json_object_new_string(sign_pub->connection_id));
     json_object_object_add(ret, "signing_id",
                            json_object_new_string(sign_pub->signing_id));
     json_object_object_add(ret, "key_id",
@@ -412,6 +423,12 @@ static union command_args *unserialize_sign_pub(
         goto err_exit;
     }
     ret->key_id = strdup(json_object_get_string(temp));
+
+    if(!json_object_object_get_ex(in, "connection_id", &temp)) {
+        LOG(LOG_LVL_CRIT, "Key \"connection_id\" does not exists.");
+        goto err_exit;
+    }
+    ret->connection_id = strdup(json_object_get_string(temp));
 
     if(!json_object_object_get_ex(in, "signing_id", &temp)) {
         LOG(LOG_LVL_CRIT, "Key \"signing_id\" does not exists.");
@@ -443,6 +460,7 @@ err_exit:
 static int delete_sign_pub(union command_args *data){
     struct sign_pub *sign_pub = &data->sign_pub;
     free((void *)sign_pub->key_id);
+    free((void *)sign_pub->connection_id);
     free((void *)sign_pub->signing_id);
     free((void *)sign_pub->message);
     free(data);

--- a/src/core/utilities.c
+++ b/src/core/utilities.c
@@ -21,7 +21,7 @@ int lookup_uint16_conf_element(const config_setting_t *setting,
         LOG(LOG_LVL_CRIT, "%s not found in the configuration.", name);
         return DTC_ERR_CONFIG_FILE;
     }
-    if(aux > UINT16_MAX){
+    if(aux > UINT16_MAX) {
         LOG(LOG_LVL_CRIT,
                   "Error getting %s. %lld is too big, should fit in uint16_t.",
                   name, aux);

--- a/src/core/utilities.c
+++ b/src/core/utilities.c
@@ -1,6 +1,7 @@
 #define _POSIX_C_SOURCE 200809L
 
 #include <inttypes.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -16,7 +17,7 @@ char *create_identity(const char *instance_id, const char *connection_id)
 {
     int ret_val;
     size_t buf_size = strlen(instance_id) + strlen(connection_id) + 2;
-    char identity = (char *) malloc(sizeof(char) * buf_size);
+    char *identity = (char *) malloc(sizeof(char) * buf_size);
 
     ret_val = snprintf(identity, buf_size, "%s-%s", instance_id,
                        connection_id);

--- a/src/core/utilities.c
+++ b/src/core/utilities.c
@@ -2,6 +2,8 @@
 
 #include <inttypes.h>
 #include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <uuid/uuid.h>
 
 #include <zmq.h>
@@ -9,6 +11,24 @@
 #include <dtc.h>
 #include "include/logger.h"
 #include "include/utilities.h"
+
+char *create_identity(const char *instance_id, const char *connection_id)
+{
+    int ret_val;
+    size_t buf_size = strlen(instance_id) + strlen(connection_id) + 2;
+    char identity = (char *) malloc(sizeof(char) * buf_size);
+
+    ret_val = snprintf(identity, buf_size, "%s-%s", instance_id,
+                       connection_id);
+    if(ret_val >= buf_size) {
+        LOG(LOG_LVL_CRIT, "Buf size:%zu not enough to store %d", buf_size,
+            ret_val);
+        free(identity);
+        return NULL;
+    }
+
+    return identity;
+}
 
 int lookup_uint16_conf_element(const config_setting_t *setting,
                                       const char *name, uint16_t *out)

--- a/src/node/database.c
+++ b/src/node/database.c
@@ -701,7 +701,6 @@ static int get_identity_and_instance_from_token(
     sqlite3_stmt *stmt;
     int ret_val, step, rc;
     size_t buf_len = strlen(sql_template) + strlen(token_name) + 1;
-    /* char *identity_ = NULL, *instance_id = NULL; */
 
     sql_query = (char *) malloc(sizeof(char) * buf_len);
     ret_val = snprintf(sql_query, buf_len, sql_template, token_name);

--- a/src/node/database.h
+++ b/src/node/database.h
@@ -7,6 +7,12 @@
 struct database_conn;
 typedef struct database_conn database_t;
 
+typedef enum mult_conn {
+    SAME_IP = -1, // Allows any number of connections, but from the same IP.
+    ONE_CONNECTION = 1 // Allows only one connection.
+} multiple_connections_t;
+
+
 /**
  * Initialize a connection with the database in path.
  * Do not use the connection from different threads, make one connection
@@ -16,12 +22,16 @@ typedef struct database_conn database_t;
  *      store the databse if it does not exits.
  * @param create_db_tables Flag that indicates whether the db tables should be
  *      created in this call of the function.
+ *  @param multiple_conn_behaviour Specify how multiple connections are
+ *      handled, see available options at the ENUM definition with its
+ *      explanations.
  *
  * @return A connection to the database to be used in the next methods,
  *      to release the connection and free the memory the user must call
  *      db_close_and_free_connection. On error NULL is returned.
  */
-database_t *db_init_connection(const char *path, int create_db_tables);
+database_t *db_init_connection(const char *path, int create_db_tables,
+                               multiple_connections_t mult_conn_behaviour);
 
 /**
  * Check if the key is a public key of an authorized master or not.
@@ -41,6 +51,10 @@ int db_is_an_authorized_key(database_t *db, const char *key);
  *  @param db Active database connection.
  *  @param instance_public_key Public key of the instance for the one we will
  *      get a new token.
+ *  @param connection_identifier Id of the connection. Introduced to allow
+ *      multiple connections by instance.
+ *  @param ip endpoint the connection is connected to. Used to restrict
+ *      connections on certain multiple connection behaviours.
  *  @param output The token will be pointed by *output if the execution is
  *      successful. *output will point to dynamic memory, the caller is
  *      responsible for freeing the memory on a successful call.
@@ -49,7 +63,8 @@ int db_is_an_authorized_key(database_t *db, const char *key);
  *      fails or -1 if the instance is not stored in the database.
  */
 int db_get_new_router_token(database_t *db, const char *instance_public_key,
-                            char **output);
+                            const char *connection_identifier,
+                            const char *ip char **output);
 
 /**
  *  Creates a new temporal token for the pub socket of the instance with the
@@ -58,6 +73,10 @@ int db_get_new_router_token(database_t *db, const char *instance_public_key,
  *  @param db Active database connection.
  *  @param instance_public_key Public key of the instance for the one we will
  *      get a new token.
+ *  @param connection_identifier Id of the connection. Introduced to allow
+ *      multiple connections by instance.
+ *  @param ip endpoint the connection is connected to. Used to restrict
+ *      connections on certain multiple connection behaviours.
  *  @param output The token will be pointed by *output if the execution is
  *      successful. *output will point to dynamic memory, the caller is
  *      responsible for freeing the memory on a successful call.
@@ -66,7 +85,8 @@ int db_get_new_router_token(database_t *db, const char *instance_public_key,
  *      fails or -1 if the instance is not stored in the database.
  */
 int db_get_new_pub_token(database_t *db, const char *instance_public_key,
-                         char **output);
+                         const char *connection_identifier,
+                         const char *ip, char **output);
 
 /**
  * Retrieve from the database the current token for the router socket of the

--- a/src/node/database.h
+++ b/src/node/database.h
@@ -119,30 +119,79 @@ int db_get_pub_token(database_t *db, const char *instance_id,
                      const char *conn_identifier, char **output);
 
 /**
- * Retrieve the instance_id of the instance with public_key.
+ * Retrieves the instance id from the token provided.
  *
  * @param db Active database connection.
- * @param public_key Public key of the instance.
- * @param ouput On a success call, the instance_id will be pointed by *output.
- *      The memory is dynamic and the caller take responsibility of freeing it
- *      on success.
+ * @param pub_token Token to be asked for its instance_id.
+ * @param output On success, the current instance_id will be pointed by *output.
+ *      In this case the caller has to free the memory.
  *
- *  @return DTC_ERR_NONE on success, a proper positive error code if something
- *      fails or -1 if the instance is not stored in the database.
+ * @return DTC_ERR_NONE on success, a proper positive error if something
+ *      fails or -1 if the token is not found in the database.
  */
-//TODO Delete this? Seems like it will not be used.
-int db_get_instance_id(database_t *db, const char *public_key, char **output);
-
 int db_get_instance_id_from_pub_token(database_t *db, const char *pub_token,
                                     char **output);
 
+/**
+ * Retrieves the instance id from the token provided.
+ *
+ * @param db Active database connection.
+ * @param router_token Token to be asked for its instance_id.
+ * @param output On success, the current instance_id will be pointed by *output.
+ *      In this case the caller has to free the memory.
+ *
+ * @return DTC_ERR_NONE on success, a proper positive error if something
+ *      fails or -1 if the token is not found in the database.
+ */
 int db_get_instance_id_from_router_token(database_t *db, const char *router_token,
                                        char **output);
 
+/** Retrieves the instance_id and the identity of the connection specified
+ * by the token, if the token does not have a connection_id specified, if
+ * the provided is not NULL, it will be set as the token's connection id.
+ *
+ * @param db Active database connection.
+ * @param pub_token The token of the pub socket that we need the identity
+ *      and instance_id for.
+ * @param connection_id If not NULL the token will take this id as its own,
+ *      if it is NULL, the connection_id of the token must be previously been
+ *      set or it will be an error, as the identity can not be determined
+ *      without the connection_id.
+ * @param identity Will be set the identity of the token, this is the address
+ *      of the router socket in order to send messages to the connection
+ *      defined by the token. This memory should be freed by the caller.
+ * @param instance_id Will be set to the instance_id of the token. This
+ *      memory should be freed by the caller.
+ *
+ * @return DTC_ERR_NONE on success, a proper positive error if something
+ *      fails or -1 if the token is not present in the database. The memory
+ *      at identity and instance_id must be freed only on DTC_ERR_NONE.
+ */
 int db_get_identity_and_instance_from_pub_token(
         database_t *db, const char *pub_token, const char *connection_id,
         char **identity, char **instance_id);
 
+/** Retrieves the instance_id and the identity of the connection specified
+ * by the token, if the token does not have a connection_id specified, if
+ * the provided is not NULL, it will be set as the token's connection id.
+ *
+ * @param db Active database connection.
+ * @param router_token The token of the router socket that we need the identity
+ *      and instance_id for.
+ * @param connection_id If not NULL the token will take this id as its own,
+ *      if it is NULL, the connection_id of the token must be previously been
+ *      set or it will be an error, as the identity can not be determined
+ *      without the connection_id.
+ * @param identity Will be set the identity of the token, this is the address
+ *      of the router socket in order to send messages to the connection
+ *      defined by the token. This memory should be freed by the caller.
+ * @param instance_id Will be set to the instance_id of the token. This
+ *      memory should be freed by the caller.
+ *
+ * @return DTC_ERR_NONE on success, a proper positive error if something
+ *      fails or -1 if the token is not present in the database. The memory
+ *      at identity and instance_id must be freed only on DTC_ERR_NONE.
+ */
 int db_get_identity_and_instance_from_router_token(
         database_t *db, const char *router_token, const char *connection_id,
         char **identity, char **instance_id);
@@ -237,5 +286,6 @@ void db_close_and_free_connection(database_t *db);
 
 // For testing purpose only, DO NOT USE IT.
 void *get_sqlite3_conn(database_t *database_conn);
+int db_get_instance_id(database_t *db, const char *public_key, char **output);
 int create_tables(database_t *db);
 #endif // DT_TCLIB_DATABASE_H_

--- a/src/node/database.h
+++ b/src/node/database.h
@@ -51,8 +51,6 @@ int db_is_an_authorized_key(database_t *db, const char *key);
  *  @param db Active database connection.
  *  @param instance_public_key Public key of the instance for the one we will
  *      get a new token.
- *  @param connection_identifier Id of the connection. Introduced to allow
- *      multiple connections by instance.
  *  @param ip endpoint the connection is connected to. Used to restrict
  *      connections on certain multiple connection behaviours.
  *  @param output The token will be pointed by *output if the execution is
@@ -63,8 +61,7 @@ int db_is_an_authorized_key(database_t *db, const char *key);
  *      fails or -1 if the instance is not stored in the database.
  */
 int db_get_new_router_token(database_t *db, const char *instance_public_key,
-                            const char *connection_identifier,
-                            const char *ip char **output);
+                            const char *ip, char **output);
 
 /**
  *  Creates a new temporal token for the pub socket of the instance with the
@@ -73,8 +70,6 @@ int db_get_new_router_token(database_t *db, const char *instance_public_key,
  *  @param db Active database connection.
  *  @param instance_public_key Public key of the instance for the one we will
  *      get a new token.
- *  @param connection_identifier Id of the connection. Introduced to allow
- *      multiple connections by instance.
  *  @param ip endpoint the connection is connected to. Used to restrict
  *      connections on certain multiple connection behaviours.
  *  @param output The token will be pointed by *output if the execution is
@@ -85,38 +80,43 @@ int db_get_new_router_token(database_t *db, const char *instance_public_key,
  *      fails or -1 if the instance is not stored in the database.
  */
 int db_get_new_pub_token(database_t *db, const char *instance_public_key,
-                         const char *connection_identifier,
                          const char *ip, char **output);
 
 /**
  * Retrieve from the database the current token for the router socket of the
- * instance specified by instance_id. This value is undefined before a call to
- * db_get_new_temp_token, since the token is generated there.
+ * connection specified by instance_id and the connection identifier. This value
+ * is undefined before a call to TODO db_get_new_temp_token, since the token is
+ * generated there.
  *
  * @param db Active database connection.
  * @param instance_id Id of the instance.
+ * @param conn_identifier The identifier of the connection.
  * @param output On success, the current token will be pointed by *output.
  *      In this case, the caller has to free the memory.
  *
  * @return DTC_ERR_NONE on successs, a proper positive error code if something
  *      fails or -1 if the instance is not stored in the database.
  **/
-int db_get_router_token(database_t *db, const char *instance_id, char **output);
+int db_get_router_token(database_t *db, const char *instance_id,
+                        const char *conn_identifier, char **output);
 
 /**
  * Retrieve from the database the current token for the pub socket of the
- * instance specified by instance_id. This value is undefined before a call to
- * db_get_new_temp_token, since the token is generated there.
+ * connection specified by instance_id and the connection_identifier. This value
+ * is undefined before a call to TODO db_get_new_temp_token, since the token is
+ * generated there.
  *
  * @param db Active database connection.
  * @param instance_id Id of the instance.
+ * @param conn_identifier The identifier of the connection.
  * @param output On success, the current token will be pointed by *output.
  *      In this case, the caller has to free the memory.
  *
  * @return DTC_ERR_NONE on successs, a proper positive error code if something
  *      fails or -1 if the instance is not stored in the database.
  **/
-int db_get_pub_token(database_t *db, const char *instance_id, char **output);
+int db_get_pub_token(database_t *db, const char *instance_id,
+                     const char *conn_identifier, char **output);
 
 /**
  * Retrieve the instance_id of the instance with public_key.
@@ -138,6 +138,14 @@ int db_get_instance_id_from_pub_token(database_t *db, const char *pub_token,
 
 int db_get_instance_id_from_router_token(database_t *db, const char *router_token,
                                        char **output);
+
+int db_get_identity_and_instance_from_pub_token(
+        database_t *db, const char *pub_token, const char *connection_id,
+        char **identity, char **instance_id);
+
+int db_get_identity_and_instance_from_router_token(
+        database_t *db, const char *router_token, const char *connection_id,
+        char **identity, char **instance_id);
 /**
  * Add a new instance to the DB, this is stored in a temporal table until
  * db_update_instances is called and the old instances are replaced by the new

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -63,6 +63,8 @@ struct worker_data {
     const char *incoming_inproc_address;
     const char *outgoing_inproc_address;
     const char *database_path;
+    // Behaviour on multiple connections.
+    multiple_connections_t  multiple_connections;
 };
 
 struct communication_objects {
@@ -87,6 +89,9 @@ struct zap_handler_data {
 
     // Path to the database file.
     const char *database;
+
+    // Behaviour on multiple connections.
+    multiple_connections_t  multiple_connections;
 };
 
 // ptr to the ctx to be used by the signal handler.
@@ -114,8 +119,10 @@ void lookup_multiple_connections(const config_setting_t *setting,
     int rc;
     multiple_connections_t ret = SAME_IP; // Default
     rc = lookup_string_conf_element(setting, "multiple_connections", &val);
-    if(rc != DTC_ERR_NONE)
+    if(rc != DTC_ERR_NONE) {
         *out = ret;
+        return;
+    }
 
     if(strcmp("SAME_IP", val) == 0)
         ret = SAME_IP;
@@ -150,7 +157,8 @@ static struct communication_objects *init_node(const struct configuration *conf)
 static struct communication_objects *create_and_bind_sockets(
         const struct configuration *conf);
 static int node_loop(struct communication_objects *communication_objs,
-                     const char * database_path, int close_fds);
+                     const char * database_path, int close_fds,
+                     multiple_connections_t mult_conn);
 static int set_server_socket_security(void *socket,
                                       const char *server_secret_key);
 static void zap_handler (void *handler);
@@ -172,7 +180,8 @@ static void print_usage(int exit_code)
 static void update_database(struct configuration *conf)
 {
     unsigned i;
-    database_t *db_conn = db_init_connection(conf->database, 1);
+    database_t *db_conn = db_init_connection(conf->database, 1,
+                                             conf->multiple_connections);
     EXIT_ON_FALSE(db_conn, "Error trying to connect to the database.");
 
     for(i = 0; i < conf->cant_masters; i++) {
@@ -223,7 +232,8 @@ int main(int argc, char **argv)
 
     LOG(LOG_LVL_NOTI, "Node started: %s", argv[0]);
 
-    ret_val = node_loop(communication_objs, configuration.database, fds[0]);
+    ret_val = node_loop(communication_objs, configuration.database, fds[0],
+                        configuration.multiple_connections);
 
     zmq_ctx_destroy(communication_objs->ctx);
     zmq_threadclose(communication_objs->zap_thread);
@@ -383,7 +393,7 @@ static int read_configuration(int argc, char *argv[],
 
 // Serialize and send an op to router, will write the instance id as first frame
 // of the message, that's used to select the destination in a router socket.
-static int send_op(const char *instance_id, const struct op_req *op, void *socket)
+static int send_op(const char *identity, const struct op_req *op, void *socket)
 {
     size_t msg_size = 0;
     char *msg_data = NULL;
@@ -404,7 +414,7 @@ static int send_op(const char *instance_id, const struct op_req *op, void *socke
         return DTC_ERR_INTERN;
     }
 
-    ret = s_sendmore(socket, instance_id);
+    ret = s_sendmore(socket, identity);
     if(ret == 0) {
         zmq_msg_close(msg);
         return DTC_ERR_COMMUNICATION;
@@ -415,7 +425,7 @@ static int send_op(const char *instance_id, const struct op_req *op, void *socke
         zmq_msg_close(msg);
         return DTC_ERR_COMMUNICATION;
     }
-    LOG(LOG_LVL_DEBG, "Sending %d to %s\n", op->op, instance_id);
+    LOG(LOG_LVL_DEBG, "Sending %d to %s\n", op->op, identity);
     return DTC_ERR_NONE;
 }
 
@@ -554,7 +564,7 @@ const signature_share_t *sign(database_t *db_conn, const char *instance_id,
 void handle_sign_pub(database_t *db_conn, void *router_socket,
                      struct op_req *pub_op, const char *auth_user)
 {
-    const char *signing_id;
+    const char *signing_id, *instance_id;
     const char *key_id;
     const uint8_t *message;
     struct op_req req;
@@ -576,7 +586,7 @@ void handle_sign_pub(database_t *db_conn, void *router_socket,
 
     msg_bytes = tc_init_bytes((void *)message, msg_len);
 
-    signature = sign(db_conn, auth_user, key_id, msg_bytes);
+    signature = sign(db_conn, instance_id, key_id, msg_bytes);
     free(msg_bytes);
 
     //TODO send status code.
@@ -598,7 +608,8 @@ void handle_sign_pub(database_t *db_conn, void *router_socket,
 void handle_store_key_pub(database_t *db_conn, void *outgoing_socket,
                           struct op_req *pub_op, const char *auth_user)
 {
-    const char *instance_id;
+    const char *connection_id, *instance_id;
+    char *identity;
     struct op_req req_op;
     struct store_key_req store_key_req;
     int ret;
@@ -608,14 +619,21 @@ void handle_store_key_pub(database_t *db_conn, void *outgoing_socket,
         return;
     }
 
-    instance_id = pub_op->args->store_key_pub.instance_id;
-    ret = strcmp(auth_user, pub_op->args->store_key_pub.instance_id);
-    printf("%s %s\n", instance_id, auth_user);
-    if(ret) {
-        LOG(LOG_LVL_NOTI, "Unauthorized user (%s) dropped at store_key_pub.",
-            instance_id);
+    connection_id = pub_op->args->store_key_pub.connection_id;
+    ret = db_get_instance_id_from_pub_token(db_conn, auth_user, &instance_id);
+    if(ret != DTC_ERR_NONE) {
+        LOG(LOG_LVL_CRIT,
+            "Error getting instance_id from handle_store_key_pub");
         return;
     }
+
+    identity = create_identity(instance_id, connection_id);
+    if(identity == NULL) {
+        LOG(LOG_LVL_CRIT, "Failed when creating identity");
+        free((void *)instance_id);
+        return;
+    }
+
     store_key_req.key_id = pub_op->args->store_key_pub.key_id;
 
     req_op.version = 1;
@@ -625,12 +643,13 @@ void handle_store_key_pub(database_t *db_conn, void *outgoing_socket,
     store_key_req.key_id_accepted =
             db_is_key_id_available(db_conn, instance_id, store_key_req.key_id);
 
-    ret = send_op(instance_id, &req_op, outgoing_socket);
-    if(ret != DTC_ERR_NONE) {
+    ret = send_op(identity, &req_op, outgoing_socket);
+    if(ret != DTC_ERR_NONE)
         LOG(LOG_LVL_CRIT, "Error replying from handle_store_key_pub: %s",
             dtc_get_error_msg(ret));
-        return;
-    }
+    free((void *)instance_id);
+    free((void *)identity);
+    return;
 }
 
 void classify_and_handle_operation(database_t *db_conn, void *outgoing_socket,
@@ -699,7 +718,8 @@ static void *worker_thr(void *thread_data)
         LOG_EXIT("Unable to connect socket: %s", zmq_strerror(errno));
     }
 
-    db_conn = db_init_connection(thr_data->database_path, 0);
+    db_conn = db_init_connection(thr_data->database_path, 0,
+                                 thr_data->multiple_connections);
     EXIT_ON_FALSE(db_conn, "Unable to init db connection at:%s",
                   thr_data->database_path);
 
@@ -754,6 +774,7 @@ static void *worker_thr(void *thread_data)
 
 static struct worker_data *create_workers(int num_workers,
                                           const char * database_path,
+                                          multiple_connections_t mult_conn,
                                           void *zmq_ctx,
                                           const char *incoming_inproc_address,
                                           const char *outgoing_inproc_address)
@@ -770,6 +791,7 @@ static struct worker_data *create_workers(int num_workers,
     worker_data->outgoing_inproc_address = outgoing_inproc_address;
     worker_data->database_path = database_path;
     worker_data->ctx = zmq_ctx;
+    worker_data->multiple_connections = mult_conn;
     for(i = 0; i < num_workers; i++) {
         ret = pthread_create(&(worker_data->pids[i]), NULL, worker_thr,
                              worker_data);
@@ -827,6 +849,7 @@ static struct communication_objects *init_node(
 
     comm_objs->workers = create_workers(num_workers,
                                         configuration->database,
+                                        configuration->multiple_connections,
                                         comm_objs->ctx,
                                         comm_objs->incoming_inproc_address,
                                         comm_objs->outgoing_inproc_address);
@@ -835,7 +858,8 @@ static struct communication_objects *init_node(
     return comm_objs;
 }
 
-static void *start_zap_security(void *zmq_ctx, const char *database)
+static void *start_zap_security(void *zmq_ctx, const char *database,
+                                multiple_connections_t mult_conn)
 {
     int ret_value;
     struct zap_handler_data *zap_data =
@@ -844,6 +868,7 @@ static void *start_zap_security(void *zmq_ctx, const char *database)
 
     zap_data->database = database;
     zap_data->socket = zmq_socket(zmq_ctx, ZMQ_REP);
+    zap_data->multiple_connections = mult_conn;
     if(zmq_setsockopt(zap_data->socket, ZMQ_LINGER, &LINGER_PERIOD, sizeof(int)))
         LOG_EXIT("LINGER FAILED");
     EXIT_ON_FALSE(zap_data->socket, "ZAP_HANDLER socket error.");
@@ -873,7 +898,8 @@ static struct communication_objects *create_and_bind_sockets(
     ret_val->ctx = zmq_ctx_new();
     EXIT_ON_FALSE(ret_val->ctx, "Context initialization error.");
 
-    ret_val->zap_thread = start_zap_security(ret_val->ctx, conf->database);
+    ret_val->zap_thread = start_zap_security(ret_val->ctx, conf->database,
+                                             conf->multiple_connections);
 
     // Create sockets.
     ret_val->incoming_socket = zmq_socket(ret_val->ctx, ZMQ_PUSH);
@@ -994,18 +1020,36 @@ static int set_server_socket_security(void *socket,
     return 0;
 }
 
+static const char *get_connection_id(const char *identity)
+{
+    static const char separator = '-';
+    const char *last_separator = identity;
+    const char *it;
+    for(it = identity; *it != '\0'; it++)
+        if(*it == separator)
+            last_separator = it;
+    if(last_separator == identity) {
+        LOG(LOG_LVL_CRIT, "Identity (%s) format not recognised", identity);
+        return it - 1; // Returns the last char of the identity
+    }
+    return last_separator;
+}
+
 static int node_loop(struct communication_objects *communication_objs,
-                     const char *database_path, int close_fds)
+                     const char *database_path, int close_fds,
+                     multiple_connections_t mult_conn)
 {
     zmq_msg_t rcvd_msg_, out_msg_;
     zmq_msg_t *rcvd_msg = &rcvd_msg_, *out_msg = &out_msg_;
     const unsigned poll_items = 4;
     const char *auth_user_id;
+    const char *connection_id;
+    const char *outgoing_address;
     char *instance_id, *identity;
     int rc = 0;
     void *out_sock;
 
-    database_t *db_conn = db_init_connection(database_path, 0);
+    database_t *db_conn = db_init_connection(database_path, 0, mult_conn);
     EXIT_ON_FALSE(db_conn, "Error trying to connect to the DB.");
 
     //TODO Check if synchronization is necessary to wait that the
@@ -1066,16 +1110,6 @@ static int node_loop(struct communication_objects *communication_objs,
                 zmq_msg_close(rcvd_msg);
                 continue;
             }
-
-            rc = db_get_instance_id_from_pub_token(db_conn, auth_user_id,
-                                                   &instance_id);
-            if(rc != DTC_ERR_NONE) {
-                LOG(LOG_LVL_ERRO, "Error retrieving instance_id from DB: %d",
-                    rc);
-                zmq_msg_close(rcvd_msg);
-                continue;
-            }
-
         }
 
         else if(items[1].revents) {
@@ -1124,7 +1158,7 @@ static int node_loop(struct communication_objects *communication_objs,
         }
 
         else if(items[2].revents) { // Probably else is enough.
-            instance_id = s_recv(communication_objs->outgoing_socket);
+            identity = s_recv(communication_objs->outgoing_socket);
             if(instance_id == NULL) {
                 LOG(LOG_LVL_ERRO, "Error reading frame 1 of outgoing_socket");
                 zmq_msg_close(rcvd_msg);
@@ -1134,7 +1168,7 @@ static int node_loop(struct communication_objects *communication_objs,
             rc = zmq_msg_recv(rcvd_msg, communication_objs->outgoing_socket, 0);
             if(rc == -1) {
                 zmq_msg_close(rcvd_msg);
-                free(instance_id);
+                free(identity);
                 LOG_EXIT("Error reading second frame of pull socket");
             }
 
@@ -1148,37 +1182,41 @@ static int node_loop(struct communication_objects *communication_objs,
             continue; //TODO or break?
         }
         //
-        if(items[0].revents || items[1].revents)
+        if(items[0].revents || items[1].revents) {
             out_sock = communication_objs->incoming_socket;
-        else if(items[2].revents)
+            outgoing_address = auth_user_id;
+        }
+        else if(items[2].revents) {
             out_sock = communication_objs->router_socket;
+            outgoing_address = identity;
+        }
 
         rc = zmq_msg_copy(out_msg, rcvd_msg);
         zmq_msg_close(rcvd_msg);
         if(rc != 0) {
             LOG(LOG_LVL_ERRO, "Unable to copy the msg:%s",
                 zmq_strerror(errno));
-            free(instance_id);
+            free(outgoing_address);
             continue;
         }
 
-        rc = s_sendmore(out_sock, instance_id);
+        rc = s_sendmore(out_sock, outgoing_address);
         if(rc == -1) {
             LOG(LOG_LVL_ERRO, "Unable to send msg: %s", zmq_strerror(errno));
             zmq_msg_close(out_msg);
-            free(instance_id);
+            free(outgoing_address);
             continue;
         }
 
         rc = zmq_msg_send(out_msg, out_sock, 0);
         if(rc == -1) {
             zmq_msg_close(out_msg);
-            free(instance_id);
+            free(outgoing_address);
             // TODO Not sure how to handle an error sending second part
             // of multipart msg, investigate it and remove the EXIT.
             LOG_EXIT("Unable to send msg: %s", zmq_strerror(errno));
         }
-        free(instance_id);
+        free(outgoing_address);
 
     }
     close(close_fds);
@@ -1192,7 +1230,6 @@ static int node_loop(struct communication_objects *communication_objs,
     return 0;
 }
 
-
 // TODO check if db_is_an_authorized_key is used, remove it if it's not.
 
 static void zap_handler(void *zap_data_)
@@ -1202,7 +1239,8 @@ static void zap_handler(void *zap_data_)
     char *aux_char;
     struct zap_handler_data *zap_data = (struct zap_handler_data *) zap_data_;
     void *sock = zap_data->socket;
-    database_t *db_conn = db_init_connection(zap_data->database, 0);
+    database_t *db_conn = db_init_connection(zap_data->database, 0,
+                                             zap_data->multiple_connections);
     EXIT_ON_FALSE(db_conn, "Error trying to connect to the DB.");
     LOG(LOG_LVL_INFO, "Starting ZAP thread.");
 
@@ -1218,7 +1256,6 @@ static void zap_handler(void *zap_data_)
         char *identity = s_recv(sock);
         char *mechanism = s_recv(sock);
 
-
         zmq_recv(sock, client_key, 32, 0);
 
         char client_key_text [42];
@@ -1227,9 +1264,15 @@ static void zap_handler(void *zap_data_)
 
         s_sendmore(sock, version);
         s_sendmore(sock, sequence);
+        /* fprintf(stderr, "Version : %s\n", version); */
+        /* fprintf(stderr, "Sequence: %s\n", sequence); */
+        /* fprintf(stderr, "Address: %s\n", address); */
+        /* fprintf(stderr, "identity: %s\n", identity); */
+        /* fprintf(stderr, "mechanism: %s\n", mechanism); */
 
         if(strcmp("SUB_SOCKET",  domain) == 0) {
             if(DTC_ERR_NONE == db_get_new_pub_token(db_conn, client_key_text,
+                                                    address,
                                                     &aux_char)) {
                 s_sendmore(sock, "200");
                 s_sendmore(sock, "OK");
@@ -1248,6 +1291,7 @@ static void zap_handler(void *zap_data_)
         }
         else if(strcmp("ROUTER_SOCKET", domain) == 0) {
             if(DTC_ERR_NONE == db_get_new_router_token(db_conn, client_key_text,
+                                                       address,
                                                        &aux_char)) {
                 s_sendmore(sock, "200");
                 s_sendmore(sock, "OK");

--- a/src/node/node.c
+++ b/src/node/node.c
@@ -1241,11 +1241,6 @@ static void zap_handler(void *zap_data_)
 
         s_sendmore(sock, version);
         s_sendmore(sock, sequence);
-        /* fprintf(stderr, "Version : %s\n", version); */
-        /* fprintf(stderr, "Sequence: %s\n", sequence); */
-        /* fprintf(stderr, "Address: %s\n", address); */
-        /* fprintf(stderr, "identity: %s\n", identity); */
-        /* fprintf(stderr, "mechanism: %s\n", mechanism); */
 
         if(strcmp("SUB_SOCKET",  domain) == 0) {
             if(DTC_ERR_NONE == db_get_new_pub_token(db_conn, client_key_text,

--- a/tests/database_test.c
+++ b/tests/database_test.c
@@ -127,6 +127,23 @@ static int check_table_number_callback(void *expected_result, int argc,
    return 0;
 }
 
+static int get_keys_callback(void *expected_keys, int cols, char **cols_data,
+                             char **cols_name) {
+    char **keys = (char **)expected_keys;
+    char *expected_metainfo = keys[0];
+    char *expected_key_share = keys[1];
+    ck_assert_ptr_ne(NULL, *keys);
+
+    ck_assert_int_eq(2, cols);
+    ck_assert_str_eq(expected_metainfo, cols_data[0]);
+    ck_assert_str_eq(expected_key_share, cols_data[1]);
+
+    // This limit the times the callback can be called to 1.
+    *keys = NULL;
+
+    return 0;
+}
+
 START_MY_TEST(test_create_db) {
     char *database_file = get_filepath("test_create_db");
 
@@ -193,7 +210,7 @@ START_MY_TEST(test_create_tables) {
 
     char *query = "SELECT COUNT(*) as count FROM sqlite_master \n"\
                   "WHERE type='table';";
-    char expected_table_number = '3';
+    char expected_table_number = '4';
     int rc = sqlite3_exec(ppDb, query, check_table_number_callback,
                           &expected_table_number, NULL);
 
@@ -232,12 +249,14 @@ START_MY_TEST(test_get_new_token_empty_db) {
     char *result;
     const char *instance_p_key = "a98478teqgdkg129*&&%^$%#$";
     char *database_file = get_filepath("test_get_new_token_empty_db");
+    const char *ip = "23.21.1.6";
     ck_assert_int_eq(-1, access(database_file, F_OK));
 
     database_t *conn = db_init_connection(database_file, 1, ONE_CONNECTION);
     ck_assert(conn != NULL);
     ck_assert_int_eq(-1,
-                     db_get_new_router_token(conn, instance_p_key, &result));
+                     db_get_new_router_token(conn, instance_p_key, ip,
+                                             &result));
 
     close_and_remove_db(database_file, conn);
 }
@@ -253,22 +272,22 @@ START_MY_TEST(test_get_new_token_instance_not_found) {
 
     ck_assert_int_eq(DTC_ERR_NONE, create_tables(conn));
 
-    ck_assert_int_eq(-1, db_get_new_pub_token(conn, "any_key", NULL));
+    ck_assert_int_eq(-1, db_get_new_pub_token(conn, "any_key", "3.1.2.2",
+                                              NULL));
 
     close_and_remove_db(database_file, conn);
 
 }
 END_TEST
 
-START_MY_TEST(test_get_new_token_consistency) {
-    //TODO WORKING HERE
+START_MY_TEST(test_get_new_token_one_connection) {
 
-    char *database_file = get_filepath("test_get_new_token_consistency");
+    char *database_file = get_filepath("test_get_new_token_one_connection");
     char *instance_key = "1(*A&S^DYHJA]&TYHJ@aklut*&@2128ha";
-    char *old_token = "no_token";
     char *instance_id = "instance_id";
     char *current_token = NULL;
-    char *result;
+    char *ip = "123.2.1.4";
+    char *result, *result2, *out;
     sqlite3 *ppDb;
 
     ck_assert_int_eq(-1, access(database_file, F_OK));
@@ -279,26 +298,218 @@ START_MY_TEST(test_get_new_token_consistency) {
     ck_assert_int_eq(DTC_ERR_NONE, create_tables(conn));
 
     ck_assert_int_eq(DTC_ERR_NONE,
-                     insert_instance(ppDb, instance_key, instance_id, old_token));
+                     new_instance(ppDb, instance_key, instance_id));
     ck_assert_int_eq(DTC_ERR_NONE,
-                     insert_instance(ppDb, "other_key", "rand_id", "token"));
+                     new_instance(ppDb, "other_key", "rand_id"));
 
     ck_assert_int_eq(DTC_ERR_NONE,
-                    db_get_new_router_token(conn, instance_key, &result));
+                     db_get_new_router_token(conn, instance_key, ip, &result));
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_new_router_token(conn, instance_key, ip, &result2));
+    ck_assert_int_ne(0, strcmp(result, result2));
+    ck_assert_int_ne(DTC_ERR_NONE,
+                     db_get_instance_id_from_router_token(conn, result, &out));
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_instance_id_from_router_token(conn, result2, &out));
+    free(out);
+    ck_assert_int_ne(DTC_ERR_NONE,
+                     db_get_instance_id_from_pub_token(conn, result, &out));
+
     free((void *)result);
+    free((void *)result2);
 
-    // Check changed token.
-    ck_assert_int_eq(DTC_ERR_NONE,
-                     db_get_router_token(conn, instance_id, &current_token));
-    ck_assert_str_ne(old_token, current_token);
-    ck_assert_str_ne("token", current_token);
     free(current_token);
 
-    //Check not changed token
+    close_and_remove_db(database_file, conn);
+}
+END_TEST
+
+START_MY_TEST(test_get_new_token_same_ip) {
+
+    char *database_file = get_filepath("test_get_new_token_same_ip");
+    char *instance_key = "1(*A&S^DYHJA]&TYHJ@aklut*&@2128ha";
+    char *instance_id = "instance_id";
+    char *ip = "192.5.8.1";
+    char *ip2 = "193.2.4.3";
+    char *result, *result2, *result3, *out;
+    sqlite3 *ppDb;
+
+    ck_assert_int_eq(-1, access(database_file, F_OK));
+    database_t *conn = db_init_connection(database_file, 1, SAME_IP);
+    ck_assert(conn != NULL);
+    ppDb = get_sqlite3_connection(conn);
+
+    ck_assert_int_eq(DTC_ERR_NONE, create_tables(conn));
+
     ck_assert_int_eq(DTC_ERR_NONE,
-                     db_get_router_token(conn, "rand_id", &current_token));
-    ck_assert_str_eq("token", current_token);
-    free(current_token);
+                     new_instance(ppDb, instance_key, instance_id));
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     new_instance(ppDb, "other_key", "rand_id"));
+
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_new_router_token(conn, instance_key, ip, &result));
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_new_router_token(conn, instance_key, ip, &result2));
+    ck_assert_int_ne(0, strcmp(result, result2));
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_instance_id_from_router_token(conn, result2, &out));
+    free(out);
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_instance_id_from_router_token(conn, result, &out));
+    free(out);
+    ck_assert_int_ne(DTC_ERR_NONE,
+                     db_get_instance_id_from_pub_token(conn, result, &out));
+
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_new_router_token(conn, instance_key, ip2, &result3));
+    // After inserting a new token with different IP, previous tokens should be
+    // discarded.
+    ck_assert_int_ne(DTC_ERR_NONE,
+                     db_get_instance_id_from_router_token(conn, result, &out));
+    ck_assert_int_ne(DTC_ERR_NONE,
+                     db_get_instance_id_from_router_token(conn, result2, &out));
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_instance_id_from_router_token(conn, result3, &out));
+    free(out);
+    free((void *)result);
+    free((void *)result2);
+    free((void *)result3);
+
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_new_pub_token(conn, instance_key, ip2, &result));
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_instance_id_from_pub_token(conn, result, &out));
+
+    free(out);
+    free(result);
+
+    close_and_remove_db(database_file, conn);
+}
+END_TEST
+
+START_MY_TEST(test_db_get_identity_and_instance) {
+
+    char *database_file = get_filepath("test_db_get_identity_and_instance");
+    char *instance_key = "1(*A&S^DYHJA]&TYHJ@aklut*&@2128ha";
+    char *instance_id = "instance_id1";
+    char *conn_id = "1312", *conn_id2 = "312";
+    char *ip = "192.5.8.1", *ip2 = "193.2.4.3";
+    char *r_token, *r_token2, *p_token, *p_token2, *identity, *instance_id_got;
+    char expected_number;
+    int rc;
+    char *sql_count_instances = "SELECT COUNT(*) as count \n"\
+                                "FROM instance_connection\n"\
+                                "WHERE instance_id = 'instance_id1';";
+    sqlite3 *ppDb;
+
+    ck_assert_int_eq(-1, access(database_file, F_OK));
+    database_t *conn = db_init_connection(database_file, 1, SAME_IP);
+    ck_assert(conn != NULL);
+    ppDb = get_sqlite3_connection(conn);
+
+    ck_assert_int_eq(DTC_ERR_NONE, create_tables(conn));
+
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     new_instance(ppDb, instance_key, instance_id));
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     new_instance(ppDb, "other_key", "rand_id"));
+
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_new_router_token(conn, instance_key, ip, &r_token));
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_new_pub_token(conn, instance_key, ip, &p_token2));
+
+    expected_number = '2';
+    rc = sqlite3_exec(ppDb, sql_count_instances, check_table_number_callback,
+                      &expected_number, NULL);
+    ck_assert_int_eq(0, rc);
+
+    ck_assert_int_eq(
+            DTC_ERR_NONE,
+            db_get_identity_and_instance_from_router_token(conn, r_token,
+                                                           conn_id, &identity,
+                                                           &instance_id_got));
+    expected_number = '2';
+    rc = sqlite3_exec(ppDb, sql_count_instances, check_table_number_callback,
+                      &expected_number, NULL);
+    ck_assert_int_eq(0, rc);
+    ck_assert_str_eq(instance_id, instance_id_got);
+    ck_assert_int_eq(0, strncmp(instance_id, identity, strlen(instance_id)));
+    free(instance_id_got);
+    free(identity);
+
+    ck_assert_int_eq(
+            DTC_ERR_NONE,
+            db_get_identity_and_instance_from_pub_token(conn, p_token2,
+                                                        conn_id2, &identity,
+                                                        &instance_id_got));
+    expected_number = '2';
+    rc = sqlite3_exec(ppDb, sql_count_instances, check_table_number_callback,
+                      &expected_number, NULL);
+    ck_assert_int_eq(0, rc);
+    ck_assert_str_eq(instance_id, instance_id_got);
+    ck_assert_int_eq(0, strncmp(instance_id, identity, strlen(instance_id)));
+    free(instance_id_got);
+    free(identity);
+
+
+
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_new_pub_token(conn, instance_key, ip, &p_token));
+    expected_number = '3';
+    rc = sqlite3_exec(ppDb, sql_count_instances, check_table_number_callback,
+                      &expected_number, NULL);
+    ck_assert_int_eq(0, rc);
+
+    ck_assert_int_eq(
+            DTC_ERR_NONE,
+            db_get_identity_and_instance_from_pub_token(conn, p_token,
+                                                        conn_id, &identity,
+                                                        &instance_id_got));
+    expected_number = '2';
+    rc = sqlite3_exec(ppDb, sql_count_instances, check_table_number_callback,
+                      &expected_number, NULL);
+    ck_assert_int_eq(0, rc);
+    ck_assert_str_eq(instance_id, instance_id_got);
+    ck_assert_int_eq(0, strncmp(instance_id, identity, strlen(instance_id)));
+    free(instance_id_got);
+    free(identity);
+
+    ck_assert_int_eq(DTC_ERR_NONE,
+                     db_get_new_router_token(conn, instance_key, ip2,
+                                             &r_token2));
+    expected_number = '1';
+    rc = sqlite3_exec(ppDb, sql_count_instances, check_table_number_callback,
+                      &expected_number, NULL);
+    ck_assert_int_eq(0, rc);
+    ck_assert_int_ne(
+            DTC_ERR_NONE,
+            db_get_identity_and_instance_from_pub_token(conn, p_token,
+                                                        conn_id, &identity,
+                                                        &instance_id_got));
+    ck_assert_int_ne(
+            DTC_ERR_NONE,
+            db_get_identity_and_instance_from_pub_token(conn, p_token2,
+                                                        conn_id, &identity,
+                                                        &instance_id_got));
+
+    ck_assert_int_ne(
+            DTC_ERR_NONE,
+            db_get_identity_and_instance_from_router_token(conn, r_token,
+                                                           conn_id, &identity,
+                                                           &instance_id_got));
+    ck_assert_int_eq(
+            DTC_ERR_NONE,
+            db_get_identity_and_instance_from_router_token(conn, r_token2,
+                                                           conn_id, &identity,
+                                                           &instance_id_got));
+    free(instance_id_got);
+    free(identity);
+
+    free(p_token);
+    free(p_token2);
+    free(r_token);
+    free(r_token2);
 
     close_and_remove_db(database_file, conn);
 }
@@ -331,7 +542,7 @@ START_MY_TEST(test_db_is_an_authorized_key) {
 
     ck_assert_int_eq(DTC_ERR_NONE, create_tables(conn));
     ck_assert_int_eq(DTC_ERR_NONE,
-                     insert_instance(ppDb, "valid_key", "id", "token"));
+                     insert_instance(ppDb, "valid_key", "id", "123.2.3.1"));
 
     ck_assert_int_eq(1, db_is_an_authorized_key(conn, "valid_key"));
     ck_assert_int_eq(0, db_is_an_authorized_key(conn, "not_valid_key"));
@@ -418,7 +629,7 @@ START_MY_TEST(test_update_instances_update_only) {
     ck_assert(conn != NULL);
     ppDb = get_sqlite3_connection(conn);
 
-    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", "token"));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", "123.2.1.2"));
 
     ck_assert_int_eq(DTC_ERR_NONE,
                      db_add_new_instance(conn, "id", "key2"));
@@ -446,7 +657,7 @@ START_MY_TEST(test_update_instances_replace) {
     ck_assert(conn != NULL);
     ppDb = get_sqlite3_connection(conn);
 
-    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", "token"));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", "192.3.1.20"));
 
     ck_assert_int_eq(DTC_ERR_NONE,
                      db_add_new_instance(conn, "id2", "key"));
@@ -474,7 +685,7 @@ START_MY_TEST(test_update_instances_nothing_to_update) {
     ck_assert(conn != NULL);
     ppDb = get_sqlite3_connection(conn);
 
-    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", "token"));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", "123.2.1.4"));
 
     ck_assert_int_eq(DTC_ERR_NONE,
                      db_add_new_instance(conn, "id", "key"));
@@ -493,6 +704,7 @@ END_TEST
 START_MY_TEST(test_update_instances_delete_only) {
     char *aux;
     char *database_file = get_filepath("test_update_instances_delete_only");
+    char *ip = "32.1.32.1";
     sqlite3 *ppDb;
 
     ck_assert_int_eq(-1, access(database_file, F_OK));
@@ -501,8 +713,8 @@ START_MY_TEST(test_update_instances_delete_only) {
     ck_assert(conn != NULL);
     ppDb = get_sqlite3_connection(conn);
 
-    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", "token"));
-    ck_assert_int_eq(0, insert_instance(ppDb, "key2", "id2", "token"));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", ip));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key2", "id2", ip));
 
     ck_assert_int_eq(DTC_ERR_NONE,
                      db_update_instances(conn));
@@ -517,6 +729,7 @@ END_TEST
 
 START_MY_TEST(test_update_instances_mix_operations) {
     char *aux;
+    char *ip = "12.213.4.2";
     char *database_file = get_filepath("test_update_instances_just_update");
     sqlite3 *ppDb;
 
@@ -526,8 +739,8 @@ START_MY_TEST(test_update_instances_mix_operations) {
     ck_assert(conn != NULL);
     ppDb = get_sqlite3_connection(conn);
 
-    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", "token"));
-    ck_assert_int_eq(0, insert_instance(ppDb, "key2", "id2", "token"));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key", "id", ip));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key2", "id2", ip));
 
     ck_assert_int_eq(DTC_ERR_NONE,
                      db_add_new_instance(conn, "id2", "updatedkey2"));
@@ -554,23 +767,6 @@ START_MY_TEST(test_update_instances_mix_operations) {
 }
 END_TEST
 
-static int get_keys_callback(void *expected_keys, int cols, char **cols_data,
-                             char **cols_name) {
-    char **keys = (char **)expected_keys;
-    char *expected_metainfo = keys[0];
-    char *expected_key_share = keys[1];
-    ck_assert_ptr_ne(NULL, *keys);
-
-    ck_assert_int_eq(2, cols);
-    ck_assert_str_eq(expected_metainfo, cols_data[0]);
-    ck_assert_str_eq(expected_key_share, cols_data[1]);
-
-    // This limit the times the callback can be called to 1.
-    *keys = NULL;
-
-    return 0;
-}
-
 START_MY_TEST(test_store_key_simple) {
     char *database_file = get_filepath("test_store_key_simple");
     char *keys[2];
@@ -586,7 +782,7 @@ START_MY_TEST(test_store_key_simple) {
     ck_assert(conn != NULL);
     ppDb = get_sqlite3_connection(conn);
 
-    ck_assert_int_eq(0, insert_instance(ppDb, "key", "s_id", "token"));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key", "s_id", "14.23.1.3"));
     //ck_assert_int_eq(0, insert_instance(conn->ppDb, "key2", "s_id2", "token"));
 
     ck_assert_int_eq(DTC_ERR_NONE,
@@ -603,7 +799,7 @@ START_MY_TEST(test_store_key_simple) {
 
     keys[0] = "key_metainfo_";
     keys[1] = "k_share_";
-    ck_assert_int_eq(0, insert_instance(ppDb, "key2", "s2_id", "token"));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key2", "s2_id", "42.102.3.1"));
     ck_assert_int_eq(DTC_ERR_NONE,
                      db_store_key(conn, "s2_id", "k_id", keys[0], keys[1]));
     ck_assert_int_ne(DTC_ERR_NONE,
@@ -633,7 +829,7 @@ START_MY_TEST(test_get_key) {
     ck_assert(conn != NULL);
     ppDb = get_sqlite3_connection(conn);
 
-    ck_assert_int_eq(0, insert_instance(ppDb, "key" ,"s_id", "token"));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key" ,"s_id", "12.3.1.2"));
 
     ck_assert_int_eq(DTC_ERR_NONE,
                      db_store_key(conn, "s_id", "k_1", keys[0][0], keys[0][1]));
@@ -664,7 +860,7 @@ START_TEST(test_delete_key_simple) {
     ck_assert(conn != NULL);
     ppDb = get_sqlite3_connection(conn);
 
-    ck_assert_int_eq(0, insert_instance(ppDb, "key", "s_id", "token"));
+    ck_assert_int_eq(0, insert_instance(ppDb, "key", "s_id", "92.3.1.2"));
 
     ck_assert_int_eq(-1,
                      db_delete_key(conn, "s_id", "k_id"));
@@ -688,11 +884,13 @@ void add_test_cases(Suite *s) {
     tcase_add_test(test_case, test_create_db_same_ip);
     tcase_add_test(test_case, test_create_tables);
     tcase_add_test(test_case, test_db_init_connection_without_creating_tables);
+    tcase_add_test(test_case, test_db_get_identity_and_instance);
     //printf("%p\n%p\n", test_get_new_token_empty_db, test_get_new_token_instance_not_found);
 
     tcase_add_test(test_case, test_get_new_token_empty_db);
     tcase_add_test(test_case, test_get_new_token_instance_not_found);
-    tcase_add_test(test_case, test_get_new_token_consistency);
+    tcase_add_test(test_case, test_get_new_token_one_connection);
+    tcase_add_test(test_case, test_get_new_token_same_ip);
 
     tcase_add_test(test_case, test_db_is_an_authorized_key_empty_db);
     tcase_add_test(test_case, test_db_is_an_authorized_key);

--- a/tests/messages_test.c
+++ b/tests/messages_test.c
@@ -6,6 +6,7 @@
 
 char *TEST_INSTANCE_ID = "instance_01";
 char *TEST_KEY_ID = "key_id_01";
+char *TEST_CONNECTION_ID = "213";
 
 START_TEST(serialize_op_req_store_key_pub_simple) {
     char *output;
@@ -13,7 +14,7 @@ START_TEST(serialize_op_req_store_key_pub_simple) {
     struct op_req operation_request;
 
     union command_args com_args;
-    com_args.store_key_pub.instance_id = TEST_INSTANCE_ID;
+    com_args.store_key_pub.connection_id = TEST_CONNECTION_ID;
     com_args.store_key_pub.key_id = TEST_KEY_ID;
     operation_request.version = 1;
     operation_request.op = OP_STORE_KEY_PUB;
@@ -45,7 +46,7 @@ START_TEST(serialize_unserialize_op_req_corrupted) {
     struct op_req *unserialized_op_req;
     union command_args com_args;
 
-    com_args.store_key_pub.instance_id = TEST_INSTANCE_ID;
+    com_args.store_key_pub.connection_id = TEST_CONNECTION_ID;
     com_args.store_key_pub.key_id = TEST_KEY_ID;
     operation_request.version = 1;
     operation_request.op = OP_STORE_KEY_PUB;
@@ -69,7 +70,7 @@ START_TEST(serialize_unserialize_op_req) {
     struct op_req *unserialized_op_req;
     union command_args com_args;
 
-    com_args.store_key_pub.instance_id = TEST_INSTANCE_ID;
+    com_args.store_key_pub.connection_id = TEST_CONNECTION_ID;
     com_args.store_key_pub.key_id = TEST_KEY_ID;
     operation_request.version = 1;
     operation_request.op = OP_STORE_KEY_PUB;
@@ -82,8 +83,8 @@ START_TEST(serialize_unserialize_op_req) {
 
     ck_assert(unserialized_op_req->version == operation_request.version);
     ck_assert(unserialized_op_req->op == operation_request.op);
-    ck_assert_str_eq(unserialized_op_req->args->store_key_pub.instance_id,
-                     com_args.store_key_pub.instance_id);
+    ck_assert_str_eq(unserialized_op_req->args->store_key_pub.connection_id,
+                     com_args.store_key_pub.connection_id);
 
     ck_assert_str_eq(unserialized_op_req->args->store_key_pub.key_id,
                      com_args.store_key_pub.key_id);
@@ -102,6 +103,7 @@ START_TEST(serialize_unserialize_delete_key_share_pub_corrupted) {
     union command_args com_args;
 
     com_args.delete_key_share_pub.key_id = TEST_KEY_ID;
+    com_args.delete_key_share_pub.connection_id = TEST_CONNECTION_ID;
     operation_request.version = 1;
     operation_request.op = OP_DELETE_KEY_SHARE_PUB;
     operation_request.args = &com_args;
@@ -128,6 +130,7 @@ START_TEST(serialize_unserialize_delete_key_share_pub) {
     union command_args com_args;
 
     com_args.delete_key_share_pub.key_id = TEST_KEY_ID;
+    com_args.delete_key_share_pub.connection_id = TEST_CONNECTION_ID;
     operation_request.version = 1;
     operation_request.op = OP_DELETE_KEY_SHARE_PUB;
     operation_request.args = &com_args;
@@ -274,6 +277,7 @@ START_TEST(serialize_unserialize_sign_pub_corrupted) {
     com_args.sign_pub.key_id = "key_id";
     com_args.sign_pub.message = (uint8_t *) "me\0ssage";
     com_args.sign_pub.msg_len = 8;
+    com_args.sign_pub.connection_id = TEST_CONNECTION_ID;
 
     operation_request.version = 1;
     operation_request.op = OP_SIGN_PUB;
@@ -303,6 +307,7 @@ START_TEST(serialize_unserialize_sign_pub) {
     com_args.sign_pub.key_id = "key_id";
     com_args.sign_pub.message = (uint8_t *) "me\0ssage";
     com_args.sign_pub.msg_len = 8;
+    com_args.sign_pub.connection_id = TEST_CONNECTION_ID;
 
     operation_request.version = 1;
     operation_request.op = OP_SIGN_PUB;
@@ -320,6 +325,8 @@ START_TEST(serialize_unserialize_sign_pub) {
                      com_args.sign_pub.msg_len);
     ck_assert_str_eq(unserialized_op_req->args->sign_pub.signing_id,
                      com_args.sign_pub.signing_id);
+    ck_assert_str_eq(unserialized_op_req->args->sign_pub.connection_id,
+                     com_args.sign_pub.connection_id);
     ck_assert_int_eq(0,
                      memcmp(unserialized_op_req->args->sign_pub.message,
                             com_args.sign_pub.message,
@@ -491,6 +498,7 @@ START_TEST(serialize_unserialized_sign) {
     sign_pub.key_id = key_id;
     sign_pub.message = (uint8_t *)prep_doc->data;
     sign_pub.msg_len = prep_doc->data_len;
+    sign_pub.connection_id = TEST_CONNECTION_ID;
     pub_msg_size = serialize_op_req(&op_sign_pub, (void *)&pub_msg);
     ck_assert_int_ne(0, pub_msg_size);
 
@@ -554,6 +562,7 @@ END_TEST
 
 TCase* get_test_case(){
     TCase *test_case = tcase_create("messages");
+    tcase_set_timeout(test_case, 10);
 
     tcase_add_test(test_case, serialize_op_req_store_key_pub_simple);
     tcase_add_test(test_case, serialize_op_req_store_key_pub_wrong_version);


### PR DESCRIPTION
This version introduces the option to open more than one connection from one instance to the nodes. There are message changes, so a node from the v0.x version are not able to talk with the dtc or libpkcs library of the v1.0 version, or viceversa. This multiplexation uses the process id, so there is still a restriction, and multiple connections must be opened from different processes.