### PR TITLE
fix compilation error on modern gcc

### DIFF
--- a/.install_dependencies.sh
+++ b/.install_dependencies.sh
@@ -13,20 +13,20 @@ sudo apt-get install -y libssl-dev
 
 wget ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz
 tar -xzC /tmp -f libffi-3.2.1.tar.gz && rm libffi-3.2.1.tar.gz
-cd /tmp/libffi-3.2.1 && ./configure && make && make install
+cd /tmp/libffi-3.2.1 && ./configure && make && sudo make install
 
 
-wget https://download.libsodium.org/libsodium/releases/old/unsupported/libsodium-1.0.9.tar.gz
-tar -xzC /tmp -f libsodium-1.0.9.tar.gz
+wget https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz
+tar -xzC /tmp -f libsodium-1.0.16.tar.gz
 
-wget https://github.com/zeromq/zeromq4-1/releases/download/v4.1.4/zeromq-4.1.4.tar.gz
-tar -xzC /tmp -f zeromq-4.1.4.tar.gz
+wget https://github.com/zeromq/zeromq4-1/releases/download/v4.1.6/zeromq-4.1.6.tar.gz
+tar -xzC /tmp -f zeromq-4.1.6.tar.gz
 
 wget https://github.com/niclabs/tchsm-libtc/archive/master.zip
 unzip master.zip -d /tmp
 
-cd /tmp/libsodium-1.0.9/ && ./configure && make && sudo make install
+cd /tmp/libsodium-1.0.16/ && ./configure && make && sudo make install
 
-cd /tmp/zeromq-4.1.4 && ./configure --with-libsodium && make && sudo make install && sudo ldconfig
+cd /tmp/zeromq-4.1.6 && ./configure --with-libsodium && make && sudo make install && sudo ldconfig
 
 cd /tmp/tchsm-libtc-master && ./.install_dependencies.sh && mkdir build && cd build && cmake .. && sudo make install

--- a/.install_dependencies.sh
+++ b/.install_dependencies.sh
@@ -16,7 +16,7 @@ tar -xzC /tmp -f libffi-3.2.1.tar.gz && rm libffi-3.2.1.tar.gz
 cd /tmp/libffi-3.2.1 && ./configure && make && make install
 
 
-wget https://download.libsodium.org/libsodium/releases/libsodium-1.0.9.tar.gz
+wget https://download.libsodium.org/libsodium/releases/old/unsupported/libsodium-1.0.9.tar.gz
 tar -xzC /tmp -f libsodium-1.0.9.tar.gz
 
 wget https://github.com/zeromq/zeromq4-1/releases/download/v4.1.4/zeromq-4.1.4.tar.gz

--- a/src/cryptoki/Session.cpp
+++ b/src/cryptoki/Session.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <algorithm>
+#include <functional>
 
 #include <botan/emsa.h>
 #include <botan/md5.h>


### PR DESCRIPTION
new versions of gcc (7.3.0) moved the std::functional definition into the header standard <functional>.